### PR TITLE
Separate upload of image files and attachments, deletion of server contents when moving to the list while writing a post

### DIFF
--- a/src/main/java/controllers/BoardController.java
+++ b/src/main/java/controllers/BoardController.java
@@ -71,13 +71,16 @@ public class BoardController extends HttpServlet {
 	            }
 	            
 	            // 세션에 저장해둔 첨부 이미지의 parentSeq를 변경
-	            List<Integer> fileSeq = (List<Integer>) request.getSession().getAttribute("fileSeq");
-	            for(int i =0;i<fileSeq.size();i++) {
-	            	fdao.updateParentSeq(parentSeq, fileSeq.get(i));
+	            if(request.getSession().getAttribute("fileSeq")!=null) {
+	            	 List<Integer> fileSeq = (List<Integer>) request.getSession().getAttribute("fileSeq");
+	 	            for(int i =0;i<fileSeq.size();i++) {
+	 	            	fdao.updateParentSeq(parentSeq, fileSeq.get(i));
+	 	            }
+	 	            
+	 	            // 첨부 이미지의 parentSeq를 변경해줬다면 session정보 지우기
+	 	            request.getSession().removeAttribute("fileSeq");
 	            }
-	            
-	            // 첨부 이미지의 parentSeq를 변경해줬다면 session정보 지우기
-	            request.getSession().removeAttribute("fileSeq");
+	           
 
 	            if (parentSeq != 0) {
 	               response.sendRedirect("/listing.board?cpage=1&category="+category);
@@ -139,6 +142,7 @@ public class BoardController extends HttpServlet {
 	            } else {
 	               // 검색 키워드가 넘어온 경우
 	            }
+	            // 게시글
 				List<BoardDTO> notiList = new ArrayList<>();
 				notiList = dao.selectByNoti();
 				

--- a/src/main/java/controllers/BoardController.java
+++ b/src/main/java/controllers/BoardController.java
@@ -59,19 +59,25 @@ public class BoardController extends HttpServlet {
 
 	            Enumeration<String> fileNames = multi.getFileNames(); // 보내진 파일들 이름의 리스트
 	            
-	            
 	            while (fileNames.hasMoreElements()) { // 파일이 존재하는 동안
 	               String fileName = fileNames.nextElement(); // 다음 파일을 불러옴
 	               if (multi.getFile(fileName) != null) {
-	            	   multi.getFile(fileName).toString();
+	            	  
 	                  String ori_name = multi.getOriginalFileName(fileName);
 	                  String sys_name = multi.getFilesystemName(fileName);
-	                  System.out.println("ori"+ori_name);
-	                  System.out.println("sys"+sys_name);
 	                  FileDTO fileDto = new FileDTO(0, parentSeq, ori_name, sys_name, false, false);
 	                  int fileResult = fdao.insert(fileDto);
 	               }
 	            }
+	            
+	            // 세션에 저장해둔 첨부 이미지의 parentSeq를 변경
+	            List<Integer> fileSeq = (List<Integer>) request.getSession().getAttribute("fileSeq");
+	            for(int i =0;i<fileSeq.size();i++) {
+	            	fdao.updateParentSeq(parentSeq, fileSeq.get(i));
+	            }
+	            
+	            // 첨부 이미지의 parentSeq를 변경해줬다면 session정보 지우기
+	            request.getSession().removeAttribute("fileSeq");
 
 	            if (parentSeq != 0) {
 	               response.sendRedirect("/listing.board?cpage=1&category="+category);
@@ -146,11 +152,22 @@ public class BoardController extends HttpServlet {
 				request.setAttribute("naviCountPerPage", Constants.NAVI_COUNT_PER_PAGE);
 				request.getRequestDispatcher("/board/boardList.jsp").forward(request, response);
 
+				// 게시글을 작성하던 중에 목록으로 넘어오게되면 절대경로에 저장되어있던 이미지 파일과 DB에 parent가 없는 이미지 파일 지우기
+				if(request.getSession().getAttribute("fileSeq")!=null) {
+					List<Integer> fileSeq = (List<Integer>) request.getSession().getAttribute("fileSeq");
+					String uploadPath = request.getServletContext().getRealPath("files");
+					
+					for(int i=0;i<fileSeq.size();i++) {
+						String fileSys_name = fdao.selectSysName(fileSeq.get(i));
+						File filepath = new File(uploadPath+"/"+fileSys_name);
+						filepath.delete();
+						fdao.deleteFile(fileSeq.get(i));
+					}
+					
+				}
 			} else if (cmd.equals("/write.board")) {
 	            String menu = request.getParameter("menu");
-	            System.out.println(menu);
 	            String category = request.getParameter("category");
-	            System.out.println(category);
 	            request.setAttribute("menu", menu);
 	            request.setAttribute("category", category);
 	            request.getRequestDispatcher("/board/boardWrite.jsp").forward(request, response);

--- a/src/main/java/controllers/FileController.java
+++ b/src/main/java/controllers/FileController.java
@@ -35,6 +35,7 @@ public class FileController extends HttpServlet {
 		String cmd = request.getRequestURI();
 		System.out.println("file cmd: "+cmd);
 
+		response.setContentType("text/html; charset=utf8"); // 한글깨짐방지
 		FileDAO dao = FileDAO.getInstance();
 		PrintWriter pw = response.getWriter();
 		Gson gson = new Gson();
@@ -56,6 +57,17 @@ public class FileController extends HttpServlet {
 				boolean isqna = Boolean.parseBoolean(multi.getParameter("isqna"));
 				Enumeration<String> fileNames = multi.getFileNames();
 				List<String> fileList = new ArrayList<>();
+				
+				// fileSeq라는 이름이 session에 존재한다면 불러와서 추가하고
+				// 없다면 새로 만들기
+				// 하나의 게시물에 이미지 첨부를 여러번 나눠서 할수도 있기 때문
+				List<Integer> fileSeq = null;
+				if(request.getSession().getAttribute("fileSeq")==null) {
+					fileSeq = new ArrayList<>();
+				}else {
+					fileSeq = (List<Integer>) request.getSession().getAttribute("fileSeq");
+				}
+				
 				while(fileNames.hasMoreElements()) {
 					String fileName = fileNames.nextElement(); 
 					
@@ -65,15 +77,15 @@ public class FileController extends HttpServlet {
 						
 						FileDTO fileDto = new FileDTO(0, 0, ori_name, sys_name, true, isqna);
 						fileList.add("/files/"+fileDto.getSystemName());
-						for(int i =0;i<fileList.size();i++) {
-							System.out.println(fileList.get(i));
-						}
-						int fileResult = dao.insert(fileDto);
+						fileSeq.add(dao.insert(fileDto));
+						
+						//int fileResult = dao.insert(fileDto);
 						//pw.append("/files/"+sys_name);
 					}
 				}
+				// 이미지 첨부 파일을 모두 DB에 저장하고 나면 DB에 저장된 seq를 세션에 모두 등록
+				request.getSession().setAttribute("fileSeq", fileSeq);
 				String result = gson.toJson(fileList);
-				System.out.println(result);
 				pw.append(result);
 				
 			} else if(cmd.equals("/download.file")) {

--- a/src/main/java/dao/BoardDAO.java
+++ b/src/main/java/dao/BoardDAO.java
@@ -120,7 +120,7 @@ public class BoardDAO {
 
 	// 공지 게시글 불러오기
 	public List<BoardDTO> selectByNoti() throws Exception {
-		String sql = "select * from board_reply_count where cbCategory = \"notice\" order by cbSeq desc;";
+		String sql = "select * from postinfo where cbCategory = \"notice\" order by cbSeq desc;";
 		List<BoardDTO> list = new ArrayList<>();
 		try (Connection con = this.getConnection();
 				PreparedStatement pstat = con.prepareStatement(sql);
@@ -135,9 +135,10 @@ public class BoardDAO {
 				int cbView = rs.getInt("cbView");
 				String cbCategory = rs.getString("cbCategory");
 				int cbRecommend = rs.getInt("cbRecommend");
-				int replyCount = rs.getInt("replyCount");
+				int fileCount = rs.getInt("fCount");
+				int replyCount = rs.getInt("rCount");
 				list.add(new BoardDTO(cbSeq, cbID, cbCategory, cbNickname, cbTitle, cbContent, cbWriteDate, cbView,
-						cbRecommend, replyCount));
+						cbRecommend, fileCount, replyCount));
 			}
 			return list;
 		}
@@ -145,7 +146,7 @@ public class BoardDAO {
 
 	// 카테고리에 해당하는 모든 게시물 불러오기
 	public List<BoardDTO> selectByCategory(String category, int start, int count) throws Exception {
-		String sql = "select *  from board_reply_count where cbCategory = ? order by cbSeq desc limit ?, ?;";
+		String sql = "select *  from postinfo where cbCategory = ? order by cbSeq desc limit ?, ?;";
 		List<BoardDTO> list = new ArrayList<>();
 		try (Connection con = this.getConnection(); PreparedStatement pstat = con.prepareStatement(sql);) {
 			pstat.setString(1, category);
@@ -162,9 +163,10 @@ public class BoardDAO {
 					int cbView = rs.getInt("cbView");
 					String cbCategory = rs.getString("cbCategory");
 					int cbRecommend = rs.getInt("cbRecommend");
-					int replyCount = rs.getInt("replyCount");
+					int fileCount = rs.getInt("fCount");
+					int replyCount = rs.getInt("rCount");
 					list.add(new BoardDTO(cbSeq, cbID, cbCategory, cbNickname, cbTitle, cbContent, cbWriteDate, cbView,
-							cbRecommend, replyCount));
+							cbRecommend, fileCount, replyCount));
 				}
 				return list;
 			}
@@ -172,7 +174,7 @@ public class BoardDAO {
 	}
 
 	public int getRecordCount(String category) throws Exception {
-		String sql = "select count(*) as count from board_reply_count where cbCategory= ?";
+		String sql = "select count(*) as count from postinfo where cbCategory= ?";
 		try (Connection con = this.getConnection();
 				PreparedStatement pstat = con.prepareStatement(sql);) {
 			pstat.setString(1, category);

--- a/src/main/java/dao/FileDAO.java
+++ b/src/main/java/dao/FileDAO.java
@@ -32,13 +32,18 @@ public class FileDAO {
 	public int insert(FileDTO dto) throws Exception{
 		String sql = "insert into file values(0,?,?,?,?,?);";
 		try(Connection con = this.getConnection();
-				PreparedStatement pstat = con.prepareStatement(sql);){
+				PreparedStatement pstat = con.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS);){
 			pstat.setInt(1, dto.getParentSeq());
 			pstat.setString(2, dto.getOriginName());
 			pstat.setString(3, dto.getSystemName());
 			pstat.setBoolean(4, dto.isImg());
 			pstat.setBoolean(5, dto.isQna());
-			return pstat.executeUpdate();
+			pstat.executeUpdate();
+			
+			try(ResultSet rs = pstat.getGeneratedKeys()){
+				rs.next();
+				return rs.getInt(1);
+			}
 		}
 	}
 	
@@ -55,6 +60,37 @@ public class FileDAO {
 				}
 				return list;
 			}
+		}
+	}
+	
+	public int updateParentSeq(int parent, int seq) throws Exception{
+		String sql = "update file set cbSeq = ? where fSeq = ?";
+		try(Connection con = this.getConnection(); PreparedStatement pstat = con.prepareStatement(sql);){
+			pstat.setInt(1, parent);
+			pstat.setInt(2, seq);
+			return pstat.executeUpdate();
+		}
+	}
+	
+	public String selectSysName(int seq) throws Exception{
+		String sql = "select fSystemName from file where fSeq=? and cbSeq=0;";
+		try(Connection con = this.getConnection(); PreparedStatement pstat = con.prepareStatement(sql);){
+			pstat.setInt(1, seq);
+			try(ResultSet rs = pstat.executeQuery();){
+				if(rs.next()) {
+					return rs.getString("fSystemName");
+				}else {
+					return null;
+				}
+			}
+		}
+	}
+	
+	public int deleteFile(int seq) throws Exception{
+		String sql = "delete from file where fSeq=? and cbSeq=0;";
+		try(Connection con = this.getConnection(); PreparedStatement pstat = con.prepareStatement(sql);){
+			pstat.setInt(1, seq);
+			return pstat.executeUpdate();
 		}
 	}
 

--- a/src/main/java/dto/BoardDTO.java
+++ b/src/main/java/dto/BoardDTO.java
@@ -13,7 +13,9 @@ public class BoardDTO {
 	private Timestamp writeDate;
 	private int view;
 	private int recommend;
-	private int replyCount;
+	private int fCount;
+	private int rCount;
+	
 
 	public BoardDTO(){}
 
@@ -32,7 +34,7 @@ public class BoardDTO {
 	}
 	
 	public BoardDTO(int seq, String writer, String category, String nickName, String title, String contents,
-			Timestamp writeDate, int view, int recommend, int replyCount) {
+			Timestamp writeDate, int view, int recommend, int fCount, int rCount) {
 		super();
 		this.seq = seq;
 		this.writer = writer;
@@ -43,7 +45,8 @@ public class BoardDTO {
 		this.writeDate = writeDate;
 		this.view = view;
 		this.recommend = recommend;
-		this.replyCount = replyCount;
+		this.fCount = fCount;
+		this.rCount = rCount;
 	}
 
 	public int getSeq() {
@@ -119,13 +122,21 @@ public class BoardDTO {
 	}
 
 	public int getReplyCount() {
-		return replyCount;
+		return rCount;
 	}
 
 	public void setReplyCount(int replyCount) {
-		this.replyCount = replyCount;
+		this.rCount = replyCount;
 	}
-	
+
+	public int getfCount() {
+		return fCount;
+	}
+
+	public void setfCount(int fCount) {
+		this.fCount = fCount;
+	}
+
 	public String timeCal(String where) {
 		long currentTime = System.currentTimeMillis();
 		long writeTime = this.writeDate.getTime();

--- a/src/main/webapp/board/boardList.jsp
+++ b/src/main/webapp/board/boardList.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
-   pageEncoding="UTF-8"%>
+	pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <!DOCTYPE html>
 <html>
@@ -16,314 +16,314 @@
 
 <!-- 부트스트랩, fontawesome -->
 <link
-   href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"
-   rel="stylesheet">
+	href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css"
+	rel="stylesheet">
 <script
-   src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+	src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet"
-   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+	href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
 <style>
 * {
-   box-sizing: border-box;
-   margin: 0px;
-   padding: 0px;
-   text-decoration: none;
-   list-style: none;
+	box-sizing: border-box;
+	margin: 0px;
+	padding: 0px;
+	text-decoration: none;
+	list-style: none;
 }
 
 .container {
-   width: 100%;
+	width: 100%;
 }
 
 a {
-   text-decoration: none;
+	text-decoration: none;
 }
 
 .dropdown-menu[data-bs-popper] {
-   right: 0;
-   left: auto;
+	right: 0;
+	left: auto;
 }
 </style>
 </head>
 <body>
-   <div class="container-fluid p-0">
-      <div class="header bColorBlack">
-         <div class="header_guide">
-            <a href="#">
-               <div class="logo fontLogo colorWhite">RUSH</div>
-            </a>
-            <nav class="navbar navbar-expand navbar-light colorWhite">
-               <div class="container-fluid p-0">
-                  <div class="collapse navbar-collapse w-100 g-0 m-0"
-                     id="navbarNavDropdown">
-                     <ul class="navbar-nav row g-0 w-100">
-                        <li class="nav-item dropdown col-3 text-end"><a
-                           class="nav-link text-white fontEnglish" href="#"
-                           id="navbarDropdownMenuLink" role="button"
-                           data-bs-toggle="dropdown" aria-expanded="false"> GAME </a>
-                           <ul class="dropdown-menu p-0"
-                              aria-labelledby="navbarDropdownMenuLink">
-                              <li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Another
-                                    action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Something
-                                    else here</a></li>
-                           </ul></li>
-                        <li class="nav-item dropdown col-3 text-end"><a
-                           class="nav-link text-white fontEnglish" href="#"
-                           id="navbarDropdownMenuLink" role="button"
-                           data-bs-toggle="dropdown" aria-expanded="false"> AWARDS </a>
-                           <ul class="dropdown-menu p-0"
-                              aria-labelledby="navbarDropdownMenuLink">
-                              <li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Another
-                                    action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Something
-                                    else here</a></li>
-                           </ul></li>
-                        <li class="nav-item dropdown col-3 text-end"><a
-                           class="nav-link text-white fontEnglish" href="#"
-                           id="navbarDropdownMenuLink" role="button"
-                           data-bs-toggle="dropdown" aria-expanded="false"> BOARD </a>
-                           <ul class="dropdown-menu p-0"
-                              aria-labelledby="navbarDropdownMenuLink">
-                              <li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Another
-                                    action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Something
-                                    else here</a></li>
-                           </ul></li>
-                        <li class="nav-item dropdown col-3 text-end"><a
-                           class="nav-link text-white fontEnglish" href="#"
-                           id="navbarDropdownMenuLink" role="button"
-                           data-bs-toggle="dropdown" aria-expanded="false"> LOGIN </a>
-                           <ul class="dropdown-menu p-0"
-                              aria-labelledby="navbarDropdownMenuLink">
-                              <li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Another
-                                    action</a></li>
-                              <li><a class="dropdown-item fontEnglish" href="#">Something
-                                    else here</a></li>
-                           </ul></li>
-                     </ul>
-                  </div>
-               </div>
-            </nav>
-         </div>
-      </div>
+	<div class="container-fluid p-0">
+		<div class="header bColorBlack">
+			<div class="header_guide">
+				<a href="#">
+					<div class="logo fontLogo colorWhite">RUSH</div>
+				</a>
+				<nav class="navbar navbar-expand navbar-light colorWhite">
+					<div class="container-fluid p-0">
+						<div class="collapse navbar-collapse w-100 g-0 m-0"
+							id="navbarNavDropdown">
+							<ul class="navbar-nav row g-0 w-100">
+								<li class="nav-item dropdown col-3 text-end"><a
+									class="nav-link text-white fontEnglish" href="#"
+									id="navbarDropdownMenuLink" role="button"
+									data-bs-toggle="dropdown" aria-expanded="false"> GAME </a>
+									<ul class="dropdown-menu p-0"
+										aria-labelledby="navbarDropdownMenuLink">
+										<li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Another
+												action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Something
+												else here</a></li>
+									</ul></li>
+								<li class="nav-item dropdown col-3 text-end"><a
+									class="nav-link text-white fontEnglish" href="#"
+									id="navbarDropdownMenuLink" role="button"
+									data-bs-toggle="dropdown" aria-expanded="false"> AWARDS </a>
+									<ul class="dropdown-menu p-0"
+										aria-labelledby="navbarDropdownMenuLink">
+										<li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Another
+												action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Something
+												else here</a></li>
+									</ul></li>
+								<li class="nav-item dropdown col-3 text-end"><a
+									class="nav-link text-white fontEnglish" href="#"
+									id="navbarDropdownMenuLink" role="button"
+									data-bs-toggle="dropdown" aria-expanded="false"> BOARD </a>
+									<ul class="dropdown-menu p-0"
+										aria-labelledby="navbarDropdownMenuLink">
+										<li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Another
+												action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Something
+												else here</a></li>
+									</ul></li>
+								<li class="nav-item dropdown col-3 text-end"><a
+									class="nav-link text-white fontEnglish" href="#"
+									id="navbarDropdownMenuLink" role="button"
+									data-bs-toggle="dropdown" aria-expanded="false"> LOGIN </a>
+									<ul class="dropdown-menu p-0"
+										aria-labelledby="navbarDropdownMenuLink">
+										<li><a class="dropdown-item fontEnglish" href="#">Action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Another
+												action</a></li>
+										<li><a class="dropdown-item fontEnglish" href="#">Something
+												else here</a></li>
+									</ul></li>
+							</ul>
+						</div>
+					</div>
+				</nav>
+			</div>
+		</div>
 
-      <div class="board">
-         <div class="board_guide">
-            <div class="boardNav">
-               <div class="boardNav_body">
-                  <a href="/listing.board?cpage=1"><div
-                        class="boardNav_li bColorGreen">자유게시판</div></a> <a
-                     href="/listing.qna?cpage=1"><div
-                        class="boardNav_li fontEnglish">Q&A</div></a>
-               </div>
-            </div>
-            <div class="boardCont">
-               <div class="boardTitle">자유게시판</div>
-               <ul class="tabs boardTabs">
-                  <a href="/listing.board?category=rhythm&cpage=1"
-                     class="rhythm current"><li class="tab-link">리듬게임</li></a>
-                  <a href="/listing.board?category=arcade&cpage=1" class="arcade"><li
-                     class="tab-link">아케이드게임</li></a>
-                  <a href="/listing.board?category=puzzle&cpage=1" class="puzzle"><li
-                     class="tab-link">퍼즐게임</li></a>
-               </ul>
+		<div class="board">
+			<div class="board_guide">
+				<div class="boardNav">
+					<div class="boardNav_body">
+						<a href="/listing.board?cpage=1"><div
+								class="boardNav_li bColorGreen">자유게시판</div></a> <a
+							href="/listing.qna?cpage=1"><div
+								class="boardNav_li fontEnglish">Q&A</div></a>
+					</div>
+				</div>
+				<div class="boardCont">
+					<div class="boardTitle">자유게시판</div>
+					<ul class="tabs boardTabs">
+						<a href="/listing.board?category=rhythm&cpage=1"
+							class="rhythm current"><li class="tab-link">리듬게임</li></a>
+						<a href="/listing.board?category=arcade&cpage=1" class="arcade"><li
+							class="tab-link">아케이드게임</li></a>
+						<a href="/listing.board?category=puzzle&cpage=1" class="puzzle"><li
+							class="tab-link">퍼즐게임</li></a>
+					</ul>
 
 
-               <div class="boardHeader">
-                  <div class="num">번호</div>
-                  <div class="title">제목</div>
-                  <div class="writer">작성자</div>
-                  <div class="date">작성일</div>
-                  <div class="view">조회</div>
-                  <div class="recommend">추천</div>
-                  <div class="file">파일</div>
-               </div>
-               <div class="boardMain">
-                  <c:forEach var="noti" items="${notiList }">
-                     <div class="post bColorBoard">
-                        <div class="maxBoard">
-                           <div class="num"></div>
-                           <div class="title">
-                              <div class="loud">
-                                 <i class="fa-solid fa-bullhorn"></i>
-                              </div>
-                              <a
-                                 href="/load.board?cpage=${cpage }&seq=${noti.seq }&category=${category }"><div
-                                    class="mainTitle">${noti.title }</div></a>
+					<div class="boardHeader">
+						<div class="num">번호</div>
+						<div class="title">제목</div>
+						<div class="writer">작성자</div>
+						<div class="date">작성일</div>
+						<div class="view">조회</div>
+						<div class="recommend">추천</div>
+						<div class="file">파일</div>
+					</div>
+					<div class="boardMain">
+						<c:forEach var="noti" items="${notiList }">
+							<div class="post bColorBoard">
+								<div class="maxBoard">
+									<div class="num"></div>
+									<div class="title">
+										<div class="loud">
+											<i class="fa-solid fa-bullhorn"></i>
+										</div>
+										<a
+											href="/load.board?cpage=${cpage }&seq=${noti.seq }&category=${category }"><div
+												class="mainTitle">${noti.title }</div></a>
 
-                              <div class="replyCnt colorPink fontEnglish">${noti.replyCount }</div>
-                           </div>
-                           <div class="writer">${noti.nickName }</div>
-                           <div class="date">${noti.stringFormat }</div>
-                           <div class="view fontEnglish">${noti.view }</div>
-                           <div class="recommend fontEnglish">${noti.recommend }</div>
-                           <div class="file">
-                              <i class="fa-solid fa-paperclip"></i>
-                           </div>
-                        </div>
-                        <div class="minBoard">
-                           <div class="num"></div>
-                           <div class="minCon">
-                              <div class="title">
-                                 <div class="loud">
-                                    <i class="fa-solid fa-bullhorn"></i>
-                                 </div>
-                                 <a
-                                    href="/load.board?cpage=${cpage }&seq=${noti.seq }&category=${category }&category=${category }"><div
-                                       class="mainTitle">${noti.title }</div></a>
-                                 <div class="replyCnt colorPink fontEnglish">${noti.replyCount }</div>
-                              </div>
-                              <div class="info">
-                                 <div class="minWriter colorDarkgray">${noti.nickName }</div>
-                                 <div class="minDate colorDarkgray">${noti.stringFormat }</div>
-                                 <div class="minView fontEnglish colorDarkgray">
-                                    <i class="fa-regular fa-eye"></i>&nbsp;${noti.view }
-                                 </div>
-                                 <div class="minRecommend fontEnglish colorDarkgray">
-                                    <i class="fa-regular fa-thumbs-up"></i>&nbsp;${noti.recommend }
-                                 </div>
-                                 <div class="minFile">
-                                    <i class="fa-solid fa-paperclip"></i>
-                                 </div>
-                              </div>
-                           </div>
-                        </div>
-                     </div>
-                  </c:forEach>
-                  <c:forEach var="post" items="${boardList }">
-                     <div class="post">
-                        <div class="maxBoard">
-                           <div class="num fontEnglish">${post.seq }</div>
-                           <div class="title">
-                              <a
-                                 href="/load.board?cpage=${cpage }&seq=${post.seq }&category=${category }"><div
-                                    class="mainTitle">${post.title }</div></a>
-                              <div class="replyCnt colorPink fontEnglish">${post.replyCount }</div>
-                           </div>
-                           <div class="writer">${post.nickName }</div>
-                           <div class="date">${post.stringFormat }</div>
-                           <div class="view fontEnglish">${post.view }</div>
-                           <div class="recommend fontEnglish">${post.recommend }</div>
-                           <div class="file">
-                              <i class="fa-solid fa-paperclip"></i>
-                           </div>
-                        </div>
-                        <div class="minBoard">
-                           <div class="num fontEnglish">${post.seq }</div>
-                           <div class="minCon">
-                              <div class="title">
-                                 <div class="loud">
-                                    <i class="fa-solid fa-bullhorn"></i>
-                                 </div>
-                                 <a href="/load.board?cpage=${cpage }&seq=${post.seq }"><div
-                                       class="mainTitle">${post.title }</div></a>
-                                 <div class="replyCnt colorPink fontEnglish">${post.replyCount }</div>
-                              </div>
-                              <div class="info">
-                                 <div class="minWriter colorDarkgray">${post.nickName }</div>
-                                 <div class="minDate colorDarkgray">${post.stringFormat }</div>
-                                 <div class="minView fontEnglish colorDarkgray">
-                                    <i class="fa-regular fa-eye"></i>&nbsp;${post.view }
-                                 </div>
-                                 <div class="minRecommend fontEnglish colorDarkgray">
-                                    <i class="fa-regular fa-thumbs-up"></i>&nbsp;${post.recommend }
-                                 </div>
-                                 <div class="minFile">
-                                    <i class="fa-solid fa-paperclip"></i>
-                                 </div>
-                              </div>
-                           </div>
-                        </div>
-                     </div>
+										<div class="replyCnt colorPink fontEnglish">${noti.replyCount }</div>
+									</div>
+									<div class="writer">${noti.nickName }</div>
+									<div class="date">${noti.stringFormat }</div>
+									<div class="view fontEnglish">${noti.view }</div>
+									<div class="recommend fontEnglish">${noti.recommend }</div>
+									<div class="file">
+										<i class="fa-solid fa-paperclip"></i>
+									</div>
+								</div>
+								<div class="minBoard">
+									<div class="num"></div>
+									<div class="minCon">
+										<div class="title">
+											<div class="loud">
+												<i class="fa-solid fa-bullhorn"></i>
+											</div>
+											<a
+												href="/load.board?cpage=${cpage }&seq=${noti.seq }&category=${category }&category=${category }"><div
+													class="mainTitle">${noti.title }</div></a>
+											<div class="replyCnt colorPink fontEnglish">${noti.replyCount }</div>
+										</div>
+										<div class="info">
+											<div class="minWriter colorDarkgray">${noti.nickName }</div>
+											<div class="minDate colorDarkgray">${noti.stringFormat }</div>
+											<div class="minView fontEnglish colorDarkgray">
+												<i class="fa-regular fa-eye"></i>&nbsp;${noti.view }
+											</div>
+											<div class="minRecommend fontEnglish colorDarkgray">
+												<i class="fa-regular fa-thumbs-up"></i>&nbsp;${noti.recommend }
+											</div>
+											<div class="minFile">
+												<i class="fa-solid fa-paperclip"></i>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</c:forEach>
+						<c:forEach var="post" items="${boardList }">
+							<div class="post">
+								<div class="maxBoard">
+									<div class="num fontEnglish">${post.seq }</div>
+									<div class="title">
+										<a
+											href="/load.board?cpage=${cpage }&seq=${post.seq }&category=${category }"><div
+												class="mainTitle">${post.title }</div></a>
+										<div class="replyCnt colorPink fontEnglish">${post.replyCount }</div>
+									</div>
+									<div class="writer">${post.nickName }</div>
+									<div class="date">${post.stringFormat }</div>
+									<div class="view fontEnglish">${post.view }</div>
+									<div class="recommend fontEnglish">${post.recommend }</div>
+									<div class="file">
+										<i class="fa-solid fa-paperclip"></i>
+									</div>
+								</div>
+								<div class="minBoard">
+									<div class="num fontEnglish">${post.seq }</div>
+									<div class="minCon">
+										<div class="title">
+											<a href="/load.board?cpage=${cpage }&seq=${post.seq }"><div
+													class="mainTitle">${post.title }</div></a>
+											<div class="replyCnt colorPink fontEnglish">${post.replyCount }</div>
+										</div>
+										<div class="info">
+											<div class="minWriter colorDarkgray">${post.nickName }</div>
+											<div class="minDate colorDarkgray">${post.stringFormat }</div>
+											<div class="minView fontEnglish colorDarkgray">
+												<i class="fa-regular fa-eye"></i>&nbsp;${post.view }
+											</div>
+											<div class="minRecommend fontEnglish colorDarkgray">
+												<i class="fa-regular fa-thumbs-up"></i>&nbsp;${post.recommend }
+											</div>
+											<c:if test="${post.fCount!=0 }">
+												<div class="minFile">
+													<i class="fa-solid fa-paperclip"></i>
+												</div>
+											</c:if>
 
-                  </c:forEach>
+										</div>
+									</div>
+								</div>
+							</div>
 
-               </div>
-               <div id="pagination"></div>
-               <div class="search_write">
-                  <div class="write"></div>
-                  <div class="search">
-                     <form action="">
-                        <div class="category">
-                           <select class="form-select" aria-label="Default select example">
-                              <option value="title" selected>제목</option>
-                              <option value="writer">작성자</option>
-                              <option value="content">내용</option>
-                           </select>
-                        </div>
-                        <div class="keyword">
-                           <input type="text">
-                        </div>
-                        <div class="sertchBtn">
-                           <input type="submit" class="boardBtn bColorGreen" value="검색">
-                        </div>
-                     </form>
+						</c:forEach>
 
-                  </div>
-                  <div class="write">
-                     <a id="writeBtnLink" href=""><input type="button" value="글쓰기"
-                        class="boardBtn bColorGreen"></a>
+					</div>
+					<div id="pagination"></div>
+					<div class="search_write">
+						<div class="write"></div>
+						<div class="search">
+							<form action="">
+								<div class="category">
+									<select class="form-select" aria-label="Default select example">
+										<option value="title" selected>제목</option>
+										<option value="writer">작성자</option>
+										<option value="content">내용</option>
+									</select>
+								</div>
+								<div class="keyword">
+									<input type="text">
+								</div>
+								<div class="sertchBtn">
+									<input type="submit" class="boardBtn bColorGreen" value="검색">
+								</div>
+							</form>
 
-                  </div>
-               </div>
-            </div>
-         </div>
-      </div>
+						</div>
+						<div class="write">
+							<a id="writeBtnLink" href=""><input type="button" value="글쓰기"
+								class="boardBtn bColorGreen"></a>
 
-      <input type="hidden" value="${category }" id="category"> <input
-         type="hidden" id="recordTotalCount" value="${recordTotalCount }">
-      <input type="hidden" id="recordCountPerPage"
-         value="${recordCountPerPage }"> <input type="hidden"
-         id="naviCountPerPage" value="${naviCountPerPage }"> <input
-         type="hidden" id="lastPageNum" value="${lastPageNum }"> <a
-         href="#">
-         <div class="upArrow bColorPink colorWhite">
-            <i class="fa-solid fa-arrow-up-long"></i>
-         </div>
-      </a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
 
-      <div class="footer bColorBlack">
-         <div class="footer_guide">
-            <div class="footer_logo fontLogo colorWhite">RUSH</div>
-            <div class="copy fontEnglish colorWhite">COPYRIGHT © SKY. ALL
-               RIGHT RESERVED</div>
-            <div class="footer_contents">
-               <div class="about conDiv fontEnglish">
-                  <div class="footer_title fontEnglish colorWhite">ABOUT US</div>
-                  <div class="footer_con ">
-                     <div class="con colorWhite">팀명 :</div>
-                     <div class="encon colorWhite">SKY</div>
-                  </div>
-               </div>
-               <div class="office conDiv fontEnglish">
-                  <div class="footer_title fontEnglish colorWhite">OFFICE</div>
-                  <div class="footer_con">
-                     <div class="con colorWhite">충청남도 천안시 서북구 천안대로 1223-24</div>
-                  </div>
-               </div>
-               <div class="contact conDiv fontEnglish">
-                  <div class="footer_title fontEnglish colorWhite">CONTACT US</div>
-                  <div class="footer_con fontEnglish">
-                     <div class="con fontEnglish colorWhite">a@naver.com</div>
-                     <div class="con fontEnglish colorWhite">01012345678</div>
-                  </div>
-               </div>
-               <div class="provision conDiv fontEnglish">
-                  <div class="footer_title fontEnglish colorWhite">PROVISION</div>
-                  <div class="footer_con">
-                     <div class="con colorWhite">개인정보 처리방침</div>
-                     <div class="con colorWhite">서비스 이용약관</div>
-                  </div>
-               </div>
-            </div>
+		<input type="hidden" value="${category }" id="category"> <input
+			type="hidden" id="recordTotalCount" value="${recordTotalCount }">
+		<input type="hidden" id="recordCountPerPage"
+			value="${recordCountPerPage }"> <input type="hidden"
+			id="naviCountPerPage" value="${naviCountPerPage }"> <input
+			type="hidden" id="lastPageNum" value="${lastPageNum }"> <a
+			href="#">
+			<div class="upArrow bColorPink colorWhite">
+				<i class="fa-solid fa-arrow-up-long"></i>
+			</div>
+		</a>
 
-         </div>
-      </div>
-   </div>
+		<div class="footer bColorBlack">
+			<div class="footer_guide">
+				<div class="footer_logo fontLogo colorWhite">RUSH</div>
+				<div class="copy fontEnglish colorWhite">COPYRIGHT © SKY. ALL
+					RIGHT RESERVED</div>
+				<div class="footer_contents">
+					<div class="about conDiv fontEnglish">
+						<div class="footer_title fontEnglish colorWhite">ABOUT US</div>
+						<div class="footer_con ">
+							<div class="con colorWhite">팀명 :</div>
+							<div class="encon colorWhite">SKY</div>
+						</div>
+					</div>
+					<div class="office conDiv fontEnglish">
+						<div class="footer_title fontEnglish colorWhite">OFFICE</div>
+						<div class="footer_con">
+							<div class="con colorWhite">충청남도 천안시 서북구 천안대로 1223-24</div>
+						</div>
+					</div>
+					<div class="contact conDiv fontEnglish">
+						<div class="footer_title fontEnglish colorWhite">CONTACT US</div>
+						<div class="footer_con fontEnglish">
+							<div class="con fontEnglish colorWhite">a@naver.com</div>
+							<div class="con fontEnglish colorWhite">01012345678</div>
+						</div>
+					</div>
+					<div class="provision conDiv fontEnglish">
+						<div class="footer_title fontEnglish colorWhite">PROVISION</div>
+						<div class="footer_con">
+							<div class="con colorWhite">개인정보 처리방침</div>
+							<div class="con colorWhite">서비스 이용약관</div>
+						</div>
+					</div>
+				</div>
+
+			</div>
+		</div>
+	</div>
 </body>
 </html>

--- a/src/main/webapp/board/boardWrite.jsp
+++ b/src/main/webapp/board/boardWrite.jsp
@@ -161,7 +161,6 @@ a {
 							<div class="fileBox">
 								<input type="button" id="btnAdd" class="writebtn bColorGreen"
 									value="+">
-								</button>
 								<span>파일첨부</span>
 								<div id="fileContainer"></div>
 							</div>

--- a/src/main/webapp/js/board/summernote_editor.js
+++ b/src/main/webapp/js/board/summernote_editor.js
@@ -20,16 +20,10 @@ $(document).ready(function() {
 					contentType: false,
 					dataType: "json",
 				}).done(function(resp) {
-					
-					console.log(resp)
-					console.log(resp.length)
-					console.log("A")
+					$("input[name=files]").val("");
 					for(let i =0;i<resp.length;i++){
-						console.log("resp[i]"+resp[i]);
 						let img = $("<img>");
-						img.attr("src", resp[i]).attr("isimg","true");
-						let imgInfo = $("<input>");
-						console.log(img)
+						img.attr("src", resp[i]);
 						$("#summernote").summernote('insertNode', img[0]);
 					}
 					
@@ -41,7 +35,6 @@ $(document).ready(function() {
 	let count = 0;
 
 	$("#btnAdd").on("click", function() {
-		console.log("b")
 		if ($("input[type=file]").length > 5) {
 			alert("파일은 5개까지 첨부 가능합니다.");
 			return false;
@@ -85,6 +78,7 @@ $(document).ready(function() {
 			return false;
 		}
 		oEditors.getById["content"].exec("UPDATE_CONTENTS_FIELD", []);
+		
 	})
 });
 


### PR DESCRIPTION
이미지 파일 및 첨부파일 구분해서 저장 완료 & 글 작성 중 게시판 목록으로 이동 시 서버에 저장된 이미지파일 삭제 구현 완료
BoarderContoller -> 세션에 저장해둔 이미지 첨부파일의 parentSeq를 변경하고 세션에 정보 제거 & 글 작성 중 완료를 누르지 않고 목록으로 돌아가는 경우 세션 정보에 남아있는 이미지 첨부파일의 경로를 찾아가 제거 및 DB내용 제거
FileController -> 한글명으로 된 파일도 확인 할 수 있도록 설정 & 이미지 첨부시 세션에 정보를 저장하도록 설정
FileDAO -> 세션 정보를 통해 업로드 된 이미지 파일들의 parentSeq를 변경 & 서버 절대경로에 저장된 이름 불러오기 & parentSeq없는 이미지 데이터 삭제
boardWrite & summernote_editor.js -> 이미지 첨부와 관련해서 files 개체에 대한 내용 비우고 사용하지 않는 input 태그 제거
